### PR TITLE
ci: follow versioning convention for (pre)releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish to VS Code Marketplace
 
 permissions:
   contents: write
@@ -6,30 +6,60 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.ref_name }}
+
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install pnpm
+      - name: Setup pnpm
         uses: pnpm/action-setup@v2
 
-      - name: Set node
+      - name: Setup Node (LTS)
         uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: pnpm
 
-      - name: Install
-        run: pnpm install
+      # ───────────────────────────────
+      # Derive version and release type
+      #
+      # v0.0.* => pré-release (MAJOR=MINOR=0)
+      # v*.1.* => pré-release (MINOR is odd)
+      # v*.2.* => release     (MINOR is even)
+      # ───────────────────────────────
+      - name: Parse SemVer from tag
+        id: semver
+        run: |
+          RAW="${TAG_NAME#v}"          # drop leading 'v'
+          echo "version=$RAW" >> "$GITHUB_OUTPUT"
 
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$RAW"
+          if (( MINOR % 2 )) || (( MAJOR == 0 && MINOR == 0 )); then
+            echo "prerelease=yes"  >> "$GITHUB_OUTPUT"   # odd or 0.0.x => pre-release
+          else
+            echo "prerelease=no"   >> "$GITHUB_OUTPUT"   # even => release
+          fi
+
+      # Install & build
+      - name: Install dependencies
+        run: pnpm install
       - name: Build
         run: pnpm run build
 
-      - name: Publish
-        run: pnpm run publish
+      # Publish with or without --pre-release
+      - name: Publish to Marketplace
+        run: |
+          if [[ "${{ steps.semver.outputs.prerelease }}" == "yes" ]]; then
+            pnpm run prepublish
+          else
+            pnpm run publish
+          fi
+
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,21 +5,21 @@
   "tasks": [
     {
       "type": "npm",
-      "script": "dev",
+      "script": "build",
       "isBackground": true,
       "presentation": {
         "reveal": "never"
       },
-      "problemMatcher": [
-        {
-          "base": "$tsc-watch",
-          "background": {
-            "activeOnStart": true,
-            "beginsPattern": "Build start",
-            "endsPattern": "(B|Reb)uild complete"
-          }
+      "problemMatcher": {
+        "owner": "typescript",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Build start",
+          "endsPattern": "(B|Reb)uild complete"
         }
-      ],
+      },
       "group": "build"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
   "engines": {
     "vscode": "^1.97.0"
   },
-  "activationEvents": [
-    "onStartupFinished"
-  ],
+  "activationEvents": [],
   "contributes": {
     "commands": [
       {
@@ -54,6 +52,7 @@
     "lint": "eslint .",
     "vscode:prepublish": "pnpm run build",
     "publish": "vsce publish --no-dependencies",
+    "prepublish": "vsce publish --pre-release --no-dependencies",
     "pack": "vsce package --no-dependencies",
     "test": "vitest",
     "typecheck": "tsc --noEmit",
@@ -65,7 +64,6 @@
     "@citation-js/plugin-csl": "^0.7.18",
     "@citation-js/plugin-doi": "^0.7.18",
     "@citation-js/plugin-isbn": "^0.4.0",
-    "@citation-js/plugin-pubmed": "^0.3.0",
     "@citation-js/plugin-software-formats": "^0.6.1",
     "@citation-js/plugin-wikidata": "^0.7.19"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@citation-js/plugin-isbn':
         specifier: ^0.4.0
         version: 0.4.0(@citation-js/core@0.7.18)
-      '@citation-js/plugin-pubmed':
-        specifier: ^0.3.0
-        version: 0.3.0(@citation-js/core@0.7.18)
       '@citation-js/plugin-software-formats':
         specifier: ^0.6.1
         version: 0.6.1
@@ -168,16 +165,16 @@ packages:
     resolution: {integrity: sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/msal-browser@4.13.1':
-    resolution: {integrity: sha512-oTp2zhVljB2CRp87swOTsBcqLDrvZq9In+yDMBzuuMN4z2wrIU6ITHBZlLfs+FaAVmM1zY3k7ITekXaJ2bsDKA==}
+  '@azure/msal-browser@4.13.2':
+    resolution: {integrity: sha512-lS75bF6FYZRwsacKLXc8UYu/jb+gOB7dtZq5938chCvV/zKTFDnzuXxCXhsSUh0p8s/P8ztgbfdueD9lFARQlQ==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@15.7.0':
-    resolution: {integrity: sha512-m9M5hoFoxhe/HlXNVa4qBHekrX60CVPkWzsjhKQGuzw/OPOmurosKRPDIMn8fug/E1hHI5v33DvT1LVJfItjcg==}
+  '@azure/msal-common@15.7.1':
+    resolution: {integrity: sha512-a0eowoYfRfKZEjbiCoA5bPT3IlWRAdGSvi63OU23Hv+X6EI8gbvXCoeqokUceFMoT9NfRUWTJSx5FiuzruqT8g==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node@3.6.0':
-    resolution: {integrity: sha512-MRZ38Ou6l9LiRkz/968mG0czfIvD1PxMZ/3Jyz5k00ZMnhNOwv+DIliEcy//laoWDobAAq+/cz97xefCcHPgjg==}
+  '@azure/msal-node@3.6.1':
+    resolution: {integrity: sha512-ctcVz4xS+st5KxOlQqgpvA+uDFAa59CvkmumnuhlD2XmNczloKBdCiMQG7/TigSlaeHe01qoOlDjz3TyUAmKUg==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.27.1':
@@ -252,12 +249,6 @@ packages:
   '@citation-js/plugin-npm@0.6.1':
     resolution: {integrity: sha512-rojJA+l/p2KBpDoY+8n0YfNyQO1Aw03fQR5BN+gXD1LNAP1V+8wqvdPsaHnzPsrhrd4ZXDR7ch/Nk0yynPkJ3Q==}
     engines: {node: '>=14.0.0'}
-
-  '@citation-js/plugin-pubmed@0.3.0':
-    resolution: {integrity: sha512-E3l83VP5UnTh6lLJaTaNBIkNgIx3U6IjDNf7j5l4geBOaOwDIhkl9X+Ss33/MMNEIMNDsBoodoMJTZ8Cq+C/ug==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@citation-js/core': '>=0.5.1 <=0.6'
 
   '@citation-js/plugin-software-formats@0.6.1':
     resolution: {integrity: sha512-BDF9rqi56K0hoTgYTVANCFVRSbWKC9V06Uap7oa8SjqCTgnHJAy8t/F3NxsyYPPG+zmRsLW9VNbcIsJOl0eu/w==}
@@ -1541,8 +1532,8 @@ packages:
     resolution: {integrity: sha512-ofkXJtn7z0urokN62DI3SBo/5xAtF0rR7tn+S/bSYV79Ka8pTajIIl+fFQ1q88DQEImymmo97M4azY3WX/nUdg==}
     engines: {node: '>=4'}
 
-  electron-to-chromium@1.5.169:
-    resolution: {integrity: sha512-q7SQx6mkLy0GTJK9K9OiWeaBMV4XQtBSdf6MJUzDB/H/5tFXfIiX38Lci1Kl6SsgiEhz1SQI1ejEOU5asWEhwQ==}
+  electron-to-chromium@1.5.170:
+    resolution: {integrity: sha512-GP+M7aeluQo9uAyiTCxgIj/j+PrWhMlY7LFVj8prlsPljd0Fdg9AprlfUi+OCSFWy9Y5/2D/Jrj9HS8Z4rpKWA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1815,8 +1806,8 @@ packages:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
 
-  exsolve@1.0.5:
-    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
+  exsolve@1.0.6:
+    resolution: {integrity: sha512-Q05uIdxhPBVBwK29gcPsl2K220xSBy52TZQPdeYWE0zOs8jM+yJ6y5h7jm6cpAo1p+OOMZRIj/Ftku4EQQBLnQ==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3469,8 +3460,8 @@ snapshots:
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.12.0
       '@azure/logger': 1.2.0
-      '@azure/msal-browser': 4.13.1
-      '@azure/msal-node': 3.6.0
+      '@azure/msal-browser': 4.13.2
+      '@azure/msal-node': 3.6.1
       open: 10.1.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -3483,15 +3474,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/msal-browser@4.13.1':
+  '@azure/msal-browser@4.13.2':
     dependencies:
-      '@azure/msal-common': 15.7.0
+      '@azure/msal-common': 15.7.1
 
-  '@azure/msal-common@15.7.0': {}
+  '@azure/msal-common@15.7.1': {}
 
-  '@azure/msal-node@3.6.0':
+  '@azure/msal-node@3.6.1':
     dependencies:
-      '@azure/msal-common': 15.7.0
+      '@azure/msal-common': 15.7.1
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
 
@@ -3573,10 +3564,6 @@ snapshots:
     dependencies:
       '@citation-js/date': 0.5.1
       '@citation-js/name': 0.4.2
-
-  '@citation-js/plugin-pubmed@0.3.0(@citation-js/core@0.7.18)':
-    dependencies:
-      '@citation-js/core': 0.7.18
 
   '@citation-js/plugin-software-formats@0.6.1':
     dependencies:
@@ -4563,7 +4550,7 @@ snapshots:
   browserslist@4.25.0:
     dependencies:
       caniuse-lite: 1.0.30001723
-      electron-to-chromium: 1.5.169
+      electron-to-chromium: 1.5.170
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
 
@@ -4604,7 +4591,7 @@ snapshots:
       confbox: 0.2.2
       defu: 6.1.4
       dotenv: 16.5.0
-      exsolve: 1.0.5
+      exsolve: 1.0.6
       giget: 2.0.0
       jiti: 2.4.2
       ohash: 2.0.11
@@ -4824,7 +4811,7 @@ snapshots:
     dependencies:
       version-range: 4.14.0
 
-  electron-to-chromium@1.5.169: {}
+  electron-to-chromium@1.5.170: {}
 
   emoji-regex@8.0.0: {}
 
@@ -5189,7 +5176,7 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  exsolve@1.0.5: {}
+  exsolve@1.0.6: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -6218,7 +6205,7 @@ snapshots:
   pkg-types@2.1.0:
     dependencies:
       confbox: 0.2.2
-      exsolve: 1.0.5
+      exsolve: 1.0.6
       pathe: 2.0.3
 
   pluralize@2.0.0: {}

--- a/src/gets.ts
+++ b/src/gets.ts
@@ -5,7 +5,6 @@ import '@citation-js/plugin-csl'
 import '@citation-js/plugin-bibtex'
 import '@citation-js/plugin-doi'
 import '@citation-js/plugin-isbn'
-import '@citation-js/plugin-pubmed'
 import '@citation-js/plugin-software-formats'
 import '@citation-js/plugin-wikidata'
 


### PR DESCRIPTION
> To publish a pre-release version, pass the --pre-release flag to the vsce package or vsce publish commands:
> 
> vsce package --pre-release
> vsce publish --pre-release
> 
> We only support major.minor.patch for extension versions, semver pre-release tags are not supported. Versions must be different between pre-release and regular releases. That is, if 1.2.3 is uploaded as a pre-release, the next regular release must be uploaded with a distinct version, such as 1.2.4. Full semver support will be available in the future.
> 
> VS Code will automatically update extensions to the highest version available, so even if a user opted-into a pre-release version and there is an extension release with a higher version, the user will be updated to the released version. So, we recommend that extensions use major.EVEN_NUMBER.patch for release versions and major.ODD_NUMBER.patch for pre-release versions. For example: 0.2.* for release and 0.3.* for pre-release.
> 
> If extension authors do not want their pre-release users to be updated to the release version, we recommend always incrementing and publishing a new pre-release version before publishing a release version to make sure that the pre-release version is always higher. Note that while pre-release users will be updated to a release version if it is higher, they still remain eligible to automatically update to future pre-releases with higher version numbers than the release version.
> 
> Pre-release extensions are supported after VS Code version 1.63.0, so all pre-release extensions should have the engines.vscode value in their package.json set to >= 1.63.0.

[Source](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions)