### PR TITLE
Add the function to add references to the bib file in the latex folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "coraldigital",
   "name": "bibref",
   "displayName": "BibRef",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "packageManager": "pnpm@10.4.1",
   "description": "A VSCode Extension for BibLaTeX-friendly bibliography management",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "publisher": "coraldigital",
   "name": "bibref",
-  "displayName": "BibRef",
-  "version": "0.2.1",
+  "displayName": "BibRef new",
+  "version": "0.3.1",
   "private": true,
   "packageManager": "pnpm@10.4.1",
   "description": "A VSCode Extension for BibLaTeX-friendly bibliography management",
@@ -34,20 +34,26 @@
       {
         "command": "bibref.fetchDOI",
         "category": "BibRef",
-        "title": "Fetch from identifier..."
+        "title": "Fetch from identifier... new"
       }
     ],
     "configuration": {
       "type": "object",
       "title": "bibref",
-      "properties": {}
+      "properties": {
+        "bibref.bibFile": {
+          "type": "string",
+          "default": "references.bib",
+          "description": "Relative path to the *.bib file to which references should be added."
+        }
+      }
     }
   },
   "scripts": {
     "tsdbuild": "tsdown src/index.ts --external vscode",
-    "build": "rm -rf dist && webpack",
+    "build": "del dist && webpack",
     "webpack": "webpack",
-    "dev": "pnpm run build --watch --sourcemap",
+    "dev": "pnpm run build --watch",
     "prepare": "pnpm run update",
     "update": "vscode-ext-gen --output src/generated/meta.ts",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "coraldigital",
   "name": "bibref",
   "displayName": "BibRef",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "packageManager": "pnpm@10.4.1",
   "description": "A VSCode Extension for BibLaTeX-friendly bibliography management",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "coraldigital",
   "name": "bibref",
   "displayName": "BibRef",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "private": true,
   "packageManager": "pnpm@10.4.1",
   "description": "A VSCode Extension for BibLaTeX-friendly bibliography management",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "publisher": "coraldigital",
   "name": "bibref",
-  "displayName": "BibRef new",
-  "version": "0.3.1",
+  "displayName": "BibRef",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.4.1",
   "description": "A VSCode Extension for BibLaTeX-friendly bibliography management",
@@ -34,26 +34,20 @@
       {
         "command": "bibref.fetchDOI",
         "category": "BibRef",
-        "title": "Fetch from identifier... new"
+        "title": "Fetch from identifier..."
       }
     ],
     "configuration": {
       "type": "object",
       "title": "bibref",
-      "properties": {
-        "bibref.bibFile": {
-          "type": "string",
-          "default": "references.bib",
-          "description": "Relative path to the *.bib file to which references should be added."
-        }
-      }
+      "properties": {}
     }
   },
   "scripts": {
     "tsdbuild": "tsdown src/index.ts --external vscode",
-    "build": "del dist && webpack",
+    "build": "rm -rf dist && webpack",
     "webpack": "webpack",
-    "dev": "pnpm run build --watch",
+    "dev": "pnpm run build --watch --sourcemap",
     "prepare": "pnpm run update",
     "update": "vscode-ext-gen --output src/generated/meta.ts",
     "lint": "eslint .",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode'
 import { getBiblatexFromId } from './gets'
+import { appendBibToFile } from './utils'
 
 export async function fetchBibFromId() {
+  const config = vscode.workspace.getConfiguration('bibref');
+  const bibFile = config.get<string>('bibFile') || 'references.bib';
   const prompt = `Enter a DOI, PMID, ISBN, Github URL, npm URL, or other identifier to fetch BibLaTeX citation.`
   const id = await vscode.window.showInputBox({ prompt })
 
@@ -16,10 +19,13 @@ export async function fetchBibFromId() {
   vscode.window.withProgress(progressOptions, async (progress, _token) => {
     progress.report({ message: `Fetching BibLaTeX for ${id}` })
     const bib = await getBiblatexFromId(id)
-    const selection = await vscode.window.showInformationMessage(bib, { title: 'Copy', isCloseAffordance: false })
-    if (selection && selection.title === 'Copy') {
-      vscode.env.clipboard.writeText(bib)
-      vscode.window.showInformationMessage('Citation copied to clipboard!')
+    const selection = await vscode.window.showInformationMessage(bib, { title: 'Add to bib', isCloseAffordance: false })
+    if (selection && selection.title === 'Add to bib') {
+      const refName = bib.match(/\{\s*([^,]+)/)
+      const bibName = refName ? refName[1].trim() : 'NA'
+      vscode.env.clipboard.writeText(bibName)
+      vscode.window.showInformationMessage(`Citation name copied to clipboard: '${bibName}'`)
+      appendBibToFile(bibFile, bib)
     }
   })
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,6 +19,10 @@ export async function fetchBibFromId() {
   vscode.window.withProgress(progressOptions, async (progress, _token) => {
     progress.report({ message: `Fetching BibLaTeX for ${id}` })
     const bib = await getBiblatexFromId(id)
+    if (!bib) {
+      vscode.window.showWarningMessage(`Could not find a citation for "${id}".`);
+      return;
+    }
     const selection = await vscode.window.showInformationMessage(bib, { title: 'Add to bib', isCloseAffordance: false })
     if (selection && selection.title === 'Add to bib') {
       const refName = bib.match(/\{\s*([^,]+)/)

--- a/src/gets.ts
+++ b/src/gets.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode'
 import { Cite } from '@citation-js/core'
 import { logger } from './utils'
 
@@ -17,6 +18,7 @@ export async function getBiblatexFromId(id: string): Promise<string> {
 
   if (cites.data.length === 0) {
     logger.error(`\n\ngetBiblatexFromId('${id}') found no references.`)
+    vscode.window.showInformationMessage(`\n\ngetBiblatexFromId('${id}') found no references.`)
     return ''
   }
   else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,9 +14,6 @@ export async function appendBibToFile(
   if (!workspaceRoot) return;
 
   const filePath = path.join(workspaceRoot, relativePath);
-  //const fileUri = vscode.Uri.file(filePath);
-  
-  //const filePath = "C:/Users/Thomas Kreeftmeijer/OneDrive - Lund University/Master's project/Article - LaTeX/references.bib"
 
   vscode.window.showInformationMessage(`File path reference files: '${filePath}'`)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,5 +23,6 @@ export async function appendBibToFile(
     }
   else {
     vscode.window.showInformationMessage(`Bib file doesn't exist, please check settings...`)
+    return;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import { appendFileSync } from 'fs';
+import { appendFile } from 'fs';
+import { existsSync } from 'fs';
 import { useLogger } from 'reactive-vscode'
 import { displayName } from './generated/meta'
 
@@ -15,7 +16,9 @@ export async function appendBibToFile(
 
   const filePath = path.join(workspaceRoot, relativePath);
 
-  vscode.window.showInformationMessage(`File path reference files: '${filePath}'`)
-
-  appendFileSync(filePath, text)
+  if (existsSync(filePath)) {
+    appendFile(filePath, text, (err) => 
+        {if (err) throw err;
+          vscode.window.showInformationMessage(`Citation added to file!`)})
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,24 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import { appendFileSync } from 'fs';
 import { useLogger } from 'reactive-vscode'
 import { displayName } from './generated/meta'
 
 export const logger = useLogger(displayName)
+
+export async function appendBibToFile(
+  relativePath: string,
+  text: string
+) {
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+  if (!workspaceRoot) return;
+
+  const filePath = path.join(workspaceRoot, relativePath);
+  //const fileUri = vscode.Uri.file(filePath);
+  
+  //const filePath = "C:/Users/Thomas Kreeftmeijer/OneDrive - Lund University/Master's project/Article - LaTeX/references.bib"
+
+  vscode.window.showInformationMessage(`File path reference files: '${filePath}'`)
+
+  appendFileSync(filePath, text)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,4 +21,7 @@ export async function appendBibToFile(
         {if (err) throw err;
           vscode.window.showInformationMessage(`Citation added to file!`)})
     }
+  else {
+    vscode.window.showInformationMessage(`Bib file doesn't exist, please check settings...`)
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "strictNullChecks": true,
     "esModuleInterop": true,
     "skipDefaultLibCheck": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "sourceMap": true
   }
 }

--- a/vscode-bibref-main.code-workspace
+++ b/vscode-bibref-main.code-workspace
@@ -1,0 +1,18 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"emeraldwalk.runonsave": {
+			"commands": [
+				{
+					"match": "package.json",
+					"isAsync": true,
+					"cmd": "npm run update"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Great work!

I have added the function (more replaced) the function to add the fetched reference directly to the end of the .bib file in the VScode workspace (file should be editable in the settings). I will copy the name of the reference so that you can directly paste it in /cite{}.

I have removed/replaced the original function (only the fetching part), because I don't need that anymore, but it should be easy to have them next to each other by renaming the function. I think that some more error catching could improve it, but this works for me without problems.